### PR TITLE
Added null checker to onFOVUpdate event.

### DIFF
--- a/src/main/java/zairus/weaponcaseloot/event/WCLEventHandler.java
+++ b/src/main/java/zairus/weaponcaseloot/event/WCLEventHandler.java
@@ -28,15 +28,18 @@ public class WCLEventHandler
 		
 		ItemStack stack = event.getEntity().getActiveItemStack();
 		
-		if (stack.getItem() instanceof WeaponBow)
+		if (stack != null)
 		{
-			WeaponBow item = (WeaponBow)stack.getItem();
-			
-			if (item.updatesFOV())
+			if (stack.getItem() instanceof WeaponBow)
 			{
-				float newfov = event.getFov() / (event.getFov() + (item.getFOVValue(stack) * getItemInUsePercentaje(event.getEntity(), item.getFOVSpeedFactor(stack))));
+				WeaponBow item = (WeaponBow)stack.getItem();
 				
-				event.setNewfov(newfov);
+				if (item.updatesFOV())
+				{
+					float newfov = event.getFov() / (event.getFov() + (item.getFOVValue(stack) * getItemInUsePercentaje(event.getEntity(), item.getFOVSpeedFactor(stack))));
+					
+					event.setNewfov(newfov);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Apparently this causes crashes with Roots' Runic Tablet, and without this null checker it could crash with other unknown items as well.
